### PR TITLE
Add logic to manage bootstrap and prepare for reprovisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Set up the [Mes Aides](https://mes-aides.gouv.fr) stack.
 The following commands run as **root** in the destination machine sets the [Mes Aides](https://mes-aides.gouv.fr) stack up.
 
 ```
-curl https://github.com/sgmap/mes-aides-ops/archive/dev.tar.gz
-tar -xvf dev.tar.gz
-cd mes-aides-ops-dev
+BRANCH_NAME=master
+wget https://github.com/sgmap/mes-aides-ops/archive/$BRANCH_NAME.tar.gz
+tar -xvf $BRANCH_NAME.tar.gz
+cd mes-aides-ops-$BRANCH_NAME
 ./bootstrap.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following commands run as **root** in the destination machine sets the [Mes 
 
 ```
 BRANCH_NAME=master
-wget https://github.com/sgmap/mes-aides-ops/archive/$BRANCH_NAME.tar.gz
+curl --location --remote-name https://github.com/sgmap/mes-aides-ops/archive/$BRANCH_NAME.tar.gz
 tar -xvf $BRANCH_NAME.tar.gz
 cd mes-aides-ops-$BRANCH_NAME
 ./bootstrap.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,11 +8,11 @@ set -ev
 wget https://apt.puppetlabs.com/puppetlabs-release-pc1-trusty.deb
 dpkg -i puppetlabs-release-pc1-trusty.deb
 apt-get update
-apt-get -y install puppet-agent
+apt-get --assume-yes install puppet-agent
 export PATH=/opt/puppetlabs/bin:$PATH
 
 DIRECTORY=/opt/mes-aides-bootstrap
-mkdir -p $DIRECTORY/manifests
+mkdir --parents $DIRECTORY/manifests
 for element in bootstrap ops
 do
     REPO_PATH=manifests/$element.pp

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,11 +5,10 @@ cd $(dirname "$BASH_SOURCE")
 set -ev
 
 # Update puppet to version >= 3.2.2 before using puppet provisioning.
-if [ ! -e puppetlabs-release-pc1-trusty.deb ]
-then
-    wget https://apt.puppetlabs.com/puppetlabs-release-pc1-trusty.deb
-fi
-dpkg --install puppetlabs-release-pc1-trusty.deb
+package_name=puppetlabs-release-pc1-trusty.deb
+# With -r re-downloading a file will result in the new copy simply overwriting the old
+curl --location --remote-name https://apt.puppetlabs.com/$package_name
+dpkg --install $package_name
 apt-get update
 apt-get --assume-yes install puppet-agent
 export PATH=/opt/puppetlabs/bin:$PATH
@@ -23,7 +22,7 @@ do
     then
         cp $REPO_PATH $DIRECTORY/$REPO_PATH
     else
-        wget --output-document=$DIRECTORY/$REPO_PATH https://raw.githubusercontent.com/sgmap/mes-aides-ops/master/$REPO_PATH
+        curl --location --output $DIRECTORY/$REPO_PATH https://raw.githubusercontent.com/sgmap/mes-aides-ops/master/$REPO_PATH
     fi
 done
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,12 +11,19 @@ apt-get update
 apt-get -y install puppet-agent
 export PATH=/opt/puppetlabs/bin:$PATH
 
-cp -f Puppetfile /opt/puppetlabs/puppet/Puppetfile
+DIRECTORY=/opt/mes-aides-bootstrap
+mkdir -p $DIRECTORY/manifests
+for element in bootstrap ops
+do
+    REPO_PATH=manifests/$element.pp
+    if [ -e $REPO_PATH ]
+    then
+        cp $REPO_PATH $DIRECTORY/$REPO_PATH
+    else
+        wget --output-document=$DIRECTORY/$REPO_PATH https://raw.githubusercontent.com/sgmap/mes-aides-ops/master/$REPO_PATH
+    fi
+done
 
-cd /opt/puppetlabs/puppet/
-gem install librarian-puppet
-librarian-puppet install
-
-cd -
-cp -r modules/mesaides /opt/puppetlabs/puppet/modules/
-/opt/puppetlabs/bin/puppet apply manifests/default.pp --verbose --modulepath=/opt/puppetlabs/puppet/modules
+puppet apply /opt/mes-aides-bootstrap/manifests/bootstrap.pp --verbose --modulepath=modules
+puppet apply /opt/mes-aides-bootstrap/manifests/ops.pp --verbose --modulepath=/opt/mes-aides-bootstrap/modules
+puppet apply /opt/mes-aides-ops/manifests/default.pp --verbose --modulepath=/opt/mes-aides-ops/modules

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,8 +5,11 @@ cd $(dirname "$BASH_SOURCE")
 set -ev
 
 # Update puppet to version >= 3.2.2 before using puppet provisioning.
-wget https://apt.puppetlabs.com/puppetlabs-release-pc1-trusty.deb
-dpkg -i puppetlabs-release-pc1-trusty.deb
+if [ ! -e puppetlabs-release-pc1-trusty.deb ]
+then
+    wget https://apt.puppetlabs.com/puppetlabs-release-pc1-trusty.deb
+fi
+dpkg --install puppetlabs-release-pc1-trusty.deb
 apt-get update
 apt-get --assume-yes install puppet-agent
 export PATH=/opt/puppetlabs/bin:$PATH

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,18 @@ do
     fi
 done
 
+# One off script that
+# * install librarian-puppet in Puppet ruby to download Puppet modules
+# * download a bootstrap Puppetfile
+# * download specified modules
 puppet apply /opt/mes-aides-bootstrap/manifests/bootstrap.pp --verbose --modulepath=modules
+
+# Script to run on mes-aides-ops update
+# * update local mes-aides-ops repository
+# * download modules
 puppet apply /opt/mes-aides-bootstrap/manifests/ops.pp --verbose --modulepath=/opt/mes-aides-bootstrap/modules
+
+# Script to run on mes-aides-ui update
+# * update local mes-aides-ui
+# * set up the full mes-aides stack
 puppet apply /opt/mes-aides-ops/manifests/default.pp --verbose --modulepath=/opt/mes-aides-ops/modules

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,6 @@ set -ev
 
 # Update puppet to version >= 3.2.2 before using puppet provisioning.
 package_name=puppetlabs-release-pc1-trusty.deb
-# With -r re-downloading a file will result in the new copy simply overwriting the old
 curl --location --remote-name https://apt.puppetlabs.com/$package_name
 dpkg --install $package_name
 apt-get update

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,10 +4,10 @@ cd $(dirname "$BASH_SOURCE")
 
 set -ev
 
-# Update puppet to version >= 3.2.2 before using puppet provisioning.
-package_name=puppetlabs-release-pc1-trusty.deb
-curl --location --remote-name https://apt.puppetlabs.com/$package_name
-dpkg --install $package_name
+LATEST_PUPPET_PACKAGE=puppetlabs-release-pc1-trusty.deb
+
+curl --location --remote-name https://apt.puppetlabs.com/$LATEST_PUPPET_PACKAGE
+dpkg --install $LATEST_PUPPET_PACKAGE
 apt-get update
 apt-get --assume-yes install puppet-agent
 export PATH=/opt/puppetlabs/bin:$PATH

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
-test:
+dependencies:
   override:
     - sudo ./bootstrap.sh
+
+test:
+  override:
+    - curl 0.0.0.0|grep 'mes-aides.gouv.fr' > /dev/null
+    - curl 0.0.0.0:8000|grep 'mes-aides.gouv.fr' > /dev/null
+    - curl 0.0.0.0:2000|grep 'Welcome, this is OpenFisca Web API.' > /dev/null

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,6 @@ dependencies:
 
 test:
   override:
-    - curl 0.0.0.0|grep 'mes-aides.gouv.fr' > /dev/null
-    - curl 0.0.0.0:8000|grep 'mes-aides.gouv.fr' > /dev/null
-    - curl 0.0.0.0:2000|grep 'Welcome, this is OpenFisca Web API.' > /dev/null
+    - curl --silent 0.0.0.0 | grep --silent 'mes-aides.gouv.fr'
+    - curl --silent 0.0.0.0:8000 | grep --silent 'mes-aides.gouv.fr'
+    - curl --silent 0.0.0.0:2000 | grep --silent OpenFisca

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - sudo ./bootstrap.sh

--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -23,4 +23,5 @@ file { '/opt/mes-aides-bootstrap/Puppetfile':
 exec { 'install puppet modules':
     command     => '/opt/puppetlabs/puppet/bin/librarian-puppet install',
     cwd         => '/opt/mes-aides-bootstrap',
+    environment => ['HOME=/root'],
 }

--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -1,0 +1,26 @@
+# Install gem in Puppet ruby environment to avoid full ruby install on host
+# https://docs.puppet.com/puppet/4.9/type.html#package-provider-puppet_gem
+package { 'librarian-puppet':
+    provider => 'puppet_gem',
+}
+
+file { [ '/opt',
+    '/opt/mes-aides-bootstrap',
+     ]:
+    ensure => directory,
+}
+
+file { '/opt/mes-aides-bootstrap/Puppetfile':
+    ensure => file,
+    source => [
+        'puppet:///modules/mesaides/Puppetfile.bootstrap',
+        'https://raw.githubusercontent.com/sgmap/mes-aides-ops/master/modules/mesaides/files/Puppetfile.bootstrap',
+    ],
+}
+
+# Use gem install in ruby embedded in Puppet
+# https://docs.puppet.com/puppet/4.9/whered_it_go.html#private-bin-directories
+exec { 'install puppet modules':
+    command     => '/opt/puppetlabs/puppet/bin/librarian-puppet install',
+    cwd         => '/opt/mes-aides-bootstrap',
+}

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -12,8 +12,9 @@ class { 'nodejs':
 include git
 
 vcsrepo { '/home/ubuntu/mes-aides-ui':
-    ensure   => present,
+    ensure   => latest,
     provider => git,
+    revision => 'master',
     source   => 'https://github.com/sgmap/mes-aides-ui.git',
     user     => 'ubuntu',
 }

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -93,13 +93,6 @@ exec { 'fetch openfisca requirements':
     user        => 'ubuntu',
 }
 
-python::pip { 'gunicorn':
-  ensure        => 'present',
-  owner         => 'ubuntu',
-  pkgname       => 'gunicorn',
-  virtualenv    => '/home/ubuntu/venv',
-}
-
 file { '/etc/init/openfisca.conf':
     ensure => file,
     owner  => 'root',
@@ -110,5 +103,5 @@ file { '/etc/init/openfisca.conf':
 
 service { 'openfisca':
     ensure  => 'running',
-    require => [ File['/etc/init/openfisca.conf'], Python::Pip['gunicorn'] ],
+    require => [ File['/etc/init/openfisca.conf'], Exec['fetch openfisca requirements'] ],
 }

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -33,7 +33,7 @@ exec { 'install node modules for mes-aides-ui':
     require     => Class['nodejs'],
     # https://docs.puppet.com/puppet/latest/types/exec.html#exec-attribute-timeout
     #  default is 300 (seconds)
-    timeout     => 600,
+    timeout     => 1800, # 30 minutes
     user        => 'ubuntu',
 }
 

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -65,13 +65,13 @@ nginx::resource::server { 'mes-aides.gouv.fr':
   require        => Service['ma-web'],
 }
 
-class { 'python' :
+class { 'python':
     dev      => 'present', # default: 'absent'
     # Can't use python gunicorn here as it would be imported from apt instead of pip
     virtualenv => 'present', # default: 'absent'
 }
 
-python::virtualenv { '/home/ubuntu/venv' :
+python::virtualenv { '/home/ubuntu/venv':
     group        => 'ubuntu',
     owner        => 'ubuntu',
     require      => [ Class['python'], Vcsrepo['/home/ubuntu/mes-aides-ui'] ],
@@ -93,7 +93,7 @@ exec { 'fetch openfisca requirements':
     user        => 'ubuntu',
 }
 
-python::pip { 'gunicorn' :
+python::pip { 'gunicorn':
   ensure        => 'present',
   owner         => 'ubuntu',
   pkgname       => 'gunicorn',

--- a/manifests/ops.pp
+++ b/manifests/ops.pp
@@ -11,4 +11,5 @@ vcsrepo { '/opt/mes-aides-ops':
 exec { 'install puppet modules':
     command     => '/opt/puppetlabs/puppet/bin/librarian-puppet install',
     cwd         => '/opt/mes-aides-ops',
+    environment => ['HOME=/root'],
 }

--- a/manifests/ops.pp
+++ b/manifests/ops.pp
@@ -1,8 +1,9 @@
 include git
 
 vcsrepo { '/opt/mes-aides-ops':
-    ensure   => present,
+    ensure   => latest,
     provider => git,
+    revision => 'master',
     source   => 'https://git@github.com/sgmap/mes-aides-ops.git',
 }
 

--- a/manifests/ops.pp
+++ b/manifests/ops.pp
@@ -3,7 +3,7 @@ include git
 vcsrepo { '/opt/mes-aides-ops':
     ensure   => present,
     provider => git,
-    source   => 'https://github.com/sgmap/mes-aides-ops.git',
+    source   => 'https://git@github.com/sgmap/mes-aides-ops.git',
 }
 
 # Use gem install in ruby embedded in Puppet

--- a/manifests/ops.pp
+++ b/manifests/ops.pp
@@ -1,0 +1,14 @@
+include git
+
+vcsrepo { '/opt/mes-aides-ops':
+    ensure   => present,
+    provider => git,
+    source   => 'https://github.com/sgmap/mes-aides-ops.git',
+}
+
+# Use gem install in ruby embedded in Puppet
+# https://docs.puppet.com/puppet/4.9/whered_it_go.html#private-bin-directories
+exec { 'install puppet modules':
+    command     => '/opt/puppetlabs/puppet/bin/librarian-puppet install',
+    cwd         => '/opt/mes-aides-ops',
+}

--- a/modules/mesaides/files/Puppetfile.bootstrap
+++ b/modules/mesaides/files/Puppetfile.bootstrap
@@ -1,0 +1,4 @@
+forge 'https://forgeapi.puppetlabs.com'
+
+mod 'puppetlabs-git', '0.5.0'
+mod 'puppetlabs-vcsrepo', '1.5.0'


### PR DESCRIPTION
Multiple puppet scripts:
* Bootstrap.pp to install puppet prerequisites
* Ops.pp to make sure mes-aides-ops is up to date
* Default.pp to set up the full stack

This does not include users for systematic re-provisioning and re-deployment

Successfully deployed at http://vps274040.ovh.net with:
```BRANCH_NAME=test_provisioning
wget https://github.com/sgmap/mes-aides-ops/archive/$BRANCH_NAME.tar.gz
tar -xvf $BRANCH_NAME.tar.gz
cd mes-aides-ops-$BRANCH_NAME
./bootstrap.sh
```