### PR TITLE
Refactor nginx_config

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -74,8 +74,9 @@ service { 'ma-web':
 }
 
 ::mesaides::nginx_config { 'vps.mes-aides.gouv.fr':
-    require => Service['ma-web'],
-    use_ssl => find_file('/opt/mes-aides/use_ssl'),
+    is_default => true,
+    require    => Service['ma-web'],
+    use_ssl    => find_file('/opt/mes-aides/use_ssl'),
 }
 
 ::mesaides::monitor { 'monitor.vps.mes-aides.gouv.fr':

--- a/modules/mesaides/manifests/monitor.pp
+++ b/modules/mesaides/manifests/monitor.pp
@@ -29,7 +29,6 @@ define mesaides::monitor () {
     }
 
     ::mesaides::nginx_config { $name:
-        is_default       => false,
         proxied_endpoint => 'http://localhost:8887',
         require          => Service['ma-monitor'],
     }

--- a/modules/mesaides/manifests/nginx_config.pp
+++ b/modules/mesaides/manifests/nginx_config.pp
@@ -1,5 +1,5 @@
 define mesaides::nginx_config (
-    $is_default = true,
+    $is_default = false,
     $use_ssl = false,
     $webroot_path = '/var/www',
     $proxied_endpoint = 'http://localhost:8000',


### PR DESCRIPTION
NGINX will fail if multiple servers are the default listener
Therefore by default the server are not set as default