### PR TITLE
Make sure nginx serves latest HTTPS certificate

### DIFF
--- a/modules/mesaides/manifests/nginx_config.pp
+++ b/modules/mesaides/manifests/nginx_config.pp
@@ -21,11 +21,12 @@ define mesaides::nginx_config (
         ensure_resource('file', $webroot_path, {'ensure' => 'directory' })
 
         letsencrypt::certonly { $name:
-            domains       => [ $name ],
-            manage_cron   => true,
-            plugin        => 'webroot',
-            require       => [ File[$webroot_path], File["/etc/nginx/sites-enabled/${name}.conf"], Service['nginx'] ],
-            webroot_paths => [ $webroot_path ],
+            cron_success_command => 'service nginx reload',
+            domains              => [ $name ],
+            manage_cron          => true,
+            plugin               => 'webroot',
+            require              => [ File[$webroot_path], File["/etc/nginx/sites-enabled/${name}.conf"], Service['nginx'] ],
+            webroot_paths        => [ $webroot_path ],
         }
     }
 }


### PR DESCRIPTION
We had an outage on production today because the HTTPS certificate for metal.mes-aides.gouv.fr expired at 12:40.

The service was not impacted because the live certificate was renewed previously. However, we received notification from UptimeRobot because it is also checking the https://metal.mes-aides.gouv.fr endpoint.

The certificate for metal.mes-aides.gouv.fr has been generated on July 21st but nginx was not reloaded so it kept on serving the previous certificate.

This triggers an nginx reload on certificat renewal.